### PR TITLE
Enable external injection of clientKey

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,15 @@
 
 You need to allow "LG Connect Apps" on your TV - see http://www.lg.com/uk/support/product-help/CT00008334-1437131798537-others
 
+- lgtv2mqtt Configuration
+
+You will need to specify the following ENV variables
+    - `TOPIC_PREFIX`: a string to be prepended to the MQTT topic hierachy this tool relies on
+    - `MQTT_HOST`: the hostname and port of the MQTT broker (eg, mqtt://mybroker.com)
+    - `TV_IP`: The IP or hostname of the LG TV
+    - `TV_CLIENT_KEY`: (optional) the key that allows this software to remain authenticated with the LG TV after authorizing on the unit. You can extract this value from `~/.lgtv2/`. See https://github.com/hobbyquaker/lgtv2?tab=readme-ov-file#options
+
+
 -   Install
 
 `npm install -g lgtv2mqtt`

--- a/index.js
+++ b/index.js
@@ -17,9 +17,20 @@ let foregroundApp = null
 
 const tvMAC = process.env.TV_MAC
 const tvIP = process.env.TV_IP
+const tvClientKey = process.env.TV_CLIENT_KEY
+const topic_prefix = process.env.TOPIC_PREFIX
+
+const tvOptions = {
+    url: 'ws://' + tvIP + ':3000',
+    reconnect: 1000
+}
+
+if (!_.isNil(tvClientKey)) {
+    tvOptions['clientKey'] = tvClientKey
+    tvOptions['saveKey'] = function(){}
+}
 
 const mqttOptions = { retain: true, qos: 1 }
-var topic_prefix = process.env.TOPIC_PREFIX
 
 if (_.isNil(topic_prefix)) {
     logging.error('TOPIC_PREFIX not set, not starting')
@@ -53,10 +64,7 @@ const powerOff = function() {
     }
 }
 
-const lgtv = new Lgtv({
-    url: 'ws://' + tvIP + ':3000',
-    reconnect: 1000
-})
+const lgtv = new Lgtv(tvOptions)
 
 mqtt.on('error', err => {
     logging.error('mqtt: ' + err)

--- a/index.js
+++ b/index.js
@@ -28,6 +28,7 @@ const tvOptions = {
 if (!_.isNil(tvClientKey)) {
     tvOptions['clientKey'] = tvClientKey
     tvOptions['saveKey'] = function(){}
+    logging.info("clientKey supplied externally")
 }
 
 const mqttOptions = { retain: true, qos: 1 }


### PR DESCRIPTION
Out of the box, the `lgtv2` library will save the `clientKey` somewhere in `$HOME/.lgtv2/`, and re-use that value on subsequent restarts. This works well, except in cases where this app doesn't have persistent storage. See https://github.com/hobbyquaker/lgtv2?tab=readme-ov-file#options

I would prefer injecting `clientKey` from outside the app, as an environment variable. This has 2 benefits.

1) The app can run in a stateless container, or with a read-only file system
2) The secret is never written to disk in plain text. I'm unsure of the risk profile of leaking the secret, but it sounds like a win.

If the `TV_CLIENT_KEY` environment variable is not specified, current behaviour will continue (prompt for authorization, and save to local disk). If it is, then the provided key will be used, and no key saving mechanism will be used.